### PR TITLE
return always ajax status and content

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -138,9 +138,9 @@
 
         xhr.onreadystatechange = function() {
             if (xhr.readyState === 4) {
-                if (xhr.status === 200) {
-                    p.done(null, xhr.responseText);
-                } else {
+                try {
+                    p.done(xhr.status, xhr.responseText);
+                } finally {
                     p.done(xhr.status, "");
                 }
             }


### PR DESCRIPTION
When I build REST applications I often use HTTP status codes as
semantic parameter, e.g. 201 for a created object that I will
return as json. This is completely valid HTTP/1.1 [1].

[1] http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
