### PR TITLE
xhr.status should accept 204 No content and 304 not modified as successful

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -151,7 +151,7 @@
                 clearTimeout(tid);
             }
             if (xhr.readyState === 4) {
-                if (xhr.status === 200) {
+                if (xhr.status >= 200 && xhr.status < 300 || xhr.status === 304) {
                     p.done(null, xhr.responseText);
                 } else {
                     p.done(xhr.status, xhr.responseText);


### PR DESCRIPTION
Basically all 200-something codes and 304 not modified are to be considered successful. 

Certainly not an expert on these things, but this solves an issue I had recently, and it's also how jQuery and Zepto treats statuses. 
