### PR TITLE
making underlying xhr request configurable using callback function on…

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,13 @@ disabled by default.
     /* Global configuration option */
     promise.ajaxTimeout = 10000;
 
+You can set underlying properties of the XMLHttpRequest object using the configuration callback property.
 
+    /* Global configuration option */
+    promise.configureXhr = function(xhr){
+        xhr.withCredentials = true;
+        return xhr;
+    };
 ## Browser compatibility
 
 The library has been successfully tested on IE5.5+ and FF1.5+

--- a/promise.js
+++ b/promise.js
@@ -111,6 +111,9 @@
                 xhr = new ActiveXObject("Microsoft.XMLHTTP");
             }
         }
+        if(promise.configureXhr instanceof Function){
+            xhr = promise.configureXhr(xhr);
+        }
         return xhr;
     }
 
@@ -203,7 +206,8 @@
          * Aborted requests resolve the promise with a ETIMEOUT error
          * code.
          */
-        ajaxTimeout: 0
+        ajaxTimeout: 0,
+        configureXhr: undefined
     };
 
     if (typeof define === 'function' && define.amd) {

--- a/tests.js
+++ b/tests.js
@@ -188,6 +188,21 @@ function test_ajax_timeout () {
         });
 }
 
+function test_xhr_configuration () {
+    promise.configureXhr = function(xhr){
+        xhr.withCredentials = true;
+        return xhr;
+    };
+
+    promise.get('/').then(
+        function(err, text, xhr) {
+            console.log(xhr.withCredentials)
+            assert(xhr.withCredentials === true, 'Properties of created xhr must be settable');
+            
+            promise.configureXhr = undefined;
+        });
+}
+
 
 function test() {
     test_simple_synchronous();
@@ -198,4 +213,5 @@ function test() {
     test_then_then();
     test_chain();
     test_ajax_timeout();
+    test_xhr_configuration();
 }


### PR DESCRIPTION
… promise configuration object

I've added a test, updated the README and implemented the solution. I used this to be able to set the `withCredentials` property (the one used in the README example but it goes for anything available on the XMLHttpRequest object (https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest)
